### PR TITLE
Refactor that restores specs, drops support for Regexps

### DIFF
--- a/boyer_moore.gemspec
+++ b/boyer_moore.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -52,7 +52,7 @@ module BoyerMoore
 
   def self.prepare_badcharacter_heuristic(str)
     result = RichHash.new
-    0.upto(str.length - 1) do |i|
+    (0...str.length).each do |i|
       result[str[i]] = i
     end
     result
@@ -64,10 +64,10 @@ module BoyerMoore
     prefix_normal = compute_prefix(normal)
     prefix_reversed = compute_prefix(reversed)
     result = []
-    0.upto(size) do |i|
+    (0..size).each do |i|
       result[i] = size - prefix_normal[size-1]
     end
-    0.upto(size-1) do |i|
+    (0...size).each do |i|
       j = size - prefix_reversed[i]
       k = i - prefix_reversed[i]+1
       result[j] = k if result[j] > k
@@ -87,7 +87,7 @@ module BoyerMoore
     size = str.length
     k = 0
     result = [0]
-    1.upto(size - 1) do |q|
+    (1...size).each do |q|
       while (k > 0) && (str[k] != str[q])
         k = result[k-1]
       end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -59,8 +59,6 @@ module BoyerMoore
       end
     end
 
-    private
-
     def character_indexes
       @char_indexes ||=
         (0...@needle.length).reduce({}) do |hash, i|

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,21 +1,16 @@
 require_relative "./boyer_moore/version"
 
 class RichHash
-
   def initialize
     @regexps = {}
     @regular = {}
   end
 
   def [](k)
-    regular = @regular[k]
-    return regular if regular
-    if @regexps.size > 0
-      @regexps.each do |regex,v|
-        return v if regex.match(k)
+    @regular[k] ||
+      @regexps.find do |regex,v|
+        regex.match(k) and break v
       end
-    end
-    nil
   end
 
   def []=(k,v)
@@ -25,7 +20,6 @@ class RichHash
       @regular[k] = v
     end
   end
-
 end
 
 module BoyerMoore

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -13,7 +13,7 @@ module BoyerMoore
           remaining == 0 and return index # SUCCESS!
         end
 
-        char_index = needle.character_indexes[haystack[index+remaining-1]] || -1
+        char_index = needle.character_index(haystack[index+remaining-1])
         skip =  if char_index < remaining && (m = remaining - char_index - 1) > needle.good_suffix[remaining]
                   m
                 else
@@ -40,6 +40,10 @@ module BoyerMoore
 
     def [](n)
       @needle[n]
+    end
+
+    def character_index(char)
+      character_indexes[char] || -1
     end
 
     def character_indexes

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -35,9 +35,8 @@ module BoyerMoore
     end
 
     def goodsuffix_heuristic(normal)
-      reversed = normal.reverse
-      prefix_normal = prefix(normal)
-      prefix_reversed = prefix(reversed)
+      prefix_normal   = prefix(normal)
+      prefix_reversed = prefix(normal.reverse)
       result = []
       (0..normal.size).each do |i|
         result[i] = normal.size - prefix_normal[normal.size-1]

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -31,10 +31,10 @@ module BoyerMoore
     index = 0
     while index <= haystack.size - needle.size
       remaining = needle.size
-      while remaining > 0 && needle_matches?(needle[remaining-1], haystack[index+remaining-1])
+      while needle_matches?(needle[remaining-1], haystack[index+remaining-1])
         remaining -= 1
+        remaining == 0 and return index # SUCCESS!
       end
-      break index if remaining == 0
 
       k = badcharacter[haystack[index+remaining-1]] || -1
       skip =  if k < remaining && (m = remaining-k-1) > goodsuffix[remaining]

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,28 +1,6 @@
 require_relative "./boyer_moore/version"
 
 module BoyerMoore
-  class RichHash
-    def initialize
-      @regexps = {}
-      @regular = {}
-    end
-
-    def [](k)
-      @regular[k] ||
-        @regexps.find do |regex,v|
-          regex.match(k) and break v
-        end
-    end
-
-    def []=(k,v)
-      if k.kind_of?(Regexp)
-        @regexps[k] = v
-      else
-        @regular[k] = v
-      end
-    end
-  end
-
   def self.search(haystack, needle)
     needle.size > 0 or raise "Must pass needle with size > 0"
     badcharacter = prepare_badcharacter_heuristic(needle)
@@ -31,7 +9,7 @@ module BoyerMoore
     index = 0
     while index <= haystack.size - needle.size
       remaining = needle.size
-      while needle_matches?(needle[remaining-1], haystack[index+remaining-1])
+      while needle[remaining-1] == haystack[index+remaining-1]
         remaining -= 1
         remaining == 0 and return index # SUCCESS!
       end
@@ -47,11 +25,10 @@ module BoyerMoore
   end
 
   def self.prepare_badcharacter_heuristic(str)
-    result = RichHash.new
-    (0...str.length).each do |i|
-      result[str[i]] = i
+    (0...str.length).reduce({}) do |hash, i|
+      hash[str[i]] = i
+      hash
     end
-    result
   end
 
   def self.prepare_goodsuffix_heuristic(normal)
@@ -68,14 +45,6 @@ module BoyerMoore
       result[j] = k if result[j] > k
     end
     result
-  end
-
-  def self.needle_matches?(needle, haystack)
-    if needle.kind_of?(Regexp)
-      needle.match(haystack)
-    else
-      needle == haystack
-    end
   end
 
   def self.compute_prefix(str)

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -6,11 +6,9 @@ module BoyerMoore
 
     haystack_index = 0
     while haystack_index <= haystack.size - needle.size
-      mismatch_index = needle.mismatch_index(haystack, haystack_index) or
-        break haystack_index # SUCCESS!
+      skip_by_index = needle.skip_by_index(haystack, haystack_index) or break haystack_index # SUCCESS!
 
-      mismatch_char = haystack[haystack_index + mismatch_index]
-      haystack_index += needle.skip_by(mismatch_char, mismatch_index)
+      haystack_index += skip_by_index
     end
   end
 
@@ -43,6 +41,14 @@ module BoyerMoore
 
     def good_suffix(compare_index)
       good_suffixes[compare_index]
+    end
+
+    def skip_by_index(haystack, haystack_index)
+      mismatch_index = mismatch_index(haystack, haystack_index) or
+        return nil # SUCCESS!
+
+      mismatch_char = haystack[haystack_index + mismatch_index]
+      skip_by(mismatch_char, mismatch_index)
     end
 
     def skip_by(mismatch_char, compare_index)

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -37,8 +37,7 @@ module BoyerMoore
         j -= 1
       end
       if j > 0
-        k = badcharacter[haystack[s+j-1]]
-        k = -1 unless k
+        k = badcharacter[haystack[s+j-1]] || -1
         if (k < j) && (m = j-k-1) > goodsuffix[j]
           s += m
         else

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -27,21 +27,22 @@ module BoyerMoore
     needle.size > 0 or raise "Must pass needle with size > 0"
     badcharacter = prepare_badcharacter_heuristic(needle)
     goodsuffix   = prepare_goodsuffix_heuristic(needle)
+
     index = 0
     while index <= haystack.size - needle.size
-      j = needle.size
-      while j > 0 && needle_matches?(needle[j-1], haystack[index+j-1])
-        j -= 1
+      remaining = needle.size
+      while remaining > 0 && needle_matches?(needle[remaining-1], haystack[index+remaining-1])
+        remaining -= 1
       end
-      if j > 0
-        k = badcharacter[haystack[index+j-1]] || -1
-        if k < j && (m = j-k-1) > goodsuffix[j]
+      if remaining <= 0
+        return index
+      else
+        k = badcharacter[haystack[index+remaining-1]] || -1
+        if k < remaining && (m = remaining-k-1) > goodsuffix[remaining]
           index += m
         else
-          index += goodsuffix[j]
+          index += goodsuffix[remaining]
         end
-      else
-        return index
       end
     end
     nil

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -34,18 +34,16 @@ module BoyerMoore
       while remaining > 0 && needle_matches?(needle[remaining-1], haystack[index+remaining-1])
         remaining -= 1
       end
-      if remaining <= 0
-        return index
-      else
-        k = badcharacter[haystack[index+remaining-1]] || -1
-        if k < remaining && (m = remaining-k-1) > goodsuffix[remaining]
-          index += m
-        else
-          index += goodsuffix[remaining]
-        end
-      end
+      break index if remaining == 0
+
+      k = badcharacter[haystack[index+remaining-1]] || -1
+      skip =  if k < remaining && (m = remaining-k-1) > goodsuffix[remaining]
+                m
+              else
+                goodsuffix[remaining]
+              end
+      index += skip
     end
-    nil
   end
 
   def self.prepare_badcharacter_heuristic(str)

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -3,8 +3,8 @@ require_relative "./boyer_moore/version"
 module BoyerMoore
   def self.search(haystack, needle)
     needle.size > 0 or raise "Must pass needle with size > 0"
-    badcharacter = prepare_badcharacter_heuristic(needle)
-    goodsuffix   = prepare_goodsuffix_heuristic(needle)
+    badcharacter = badcharacter_heuristic(needle)
+    goodsuffix   = goodsuffix_heuristic(needle)
 
     index = 0
     while index <= haystack.size - needle.size
@@ -24,14 +24,14 @@ module BoyerMoore
     end
   end
 
-  def self.prepare_badcharacter_heuristic(str)
+  def self.badcharacter_heuristic(str)
     (0...str.length).reduce({}) do |hash, i|
       hash[str[i]] = i
       hash
     end
   end
 
-  def self.prepare_goodsuffix_heuristic(normal)
+  def self.goodsuffix_heuristic(normal)
     reversed = normal.reverse
     prefix_normal = compute_prefix(normal)
     prefix_reversed = compute_prefix(reversed)
@@ -53,7 +53,7 @@ module BoyerMoore
       while (k > 0) && (str[k] != str[q])
         k = prefix[k-1]
       end
-      k += 1 if str[k] == str[q]
+      str[k] == str[q] and k += 1
       prefix[q] = k
       prefix
     end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,61 +1,63 @@
 require_relative "./boyer_moore/version"
 
 module BoyerMoore
-  def self.search(haystack, needle)
-    needle.size > 0 or raise "Must pass needle with size > 0"
-    badcharacter = badcharacter_heuristic(needle)
-    goodsuffix   = goodsuffix_heuristic(needle)
+  class << self
+    def search(haystack, needle)
+      needle.size > 0 or raise "Must pass needle with size > 0"
+      badcharacter = badcharacter_heuristic(needle)
+      goodsuffix   = goodsuffix_heuristic(needle)
 
-    index = 0
-    while index <= haystack.size - needle.size
-      remaining = needle.size
-      while needle[remaining-1] == haystack[index+remaining-1]
-        remaining -= 1
-        remaining == 0 and return index # SUCCESS!
+      index = 0
+      while index <= haystack.size - needle.size
+        remaining = needle.size
+        while needle[remaining-1] == haystack[index+remaining-1]
+          remaining -= 1
+          remaining == 0 and return index # SUCCESS!
+        end
+
+        k = badcharacter[haystack[index+remaining-1]] || -1
+        skip =  if k < remaining && (m = remaining-k-1) > goodsuffix[remaining]
+                  m
+                else
+                  goodsuffix[remaining]
+                end
+        index += skip
       end
-
-      k = badcharacter[haystack[index+remaining-1]] || -1
-      skip =  if k < remaining && (m = remaining-k-1) > goodsuffix[remaining]
-                m
-              else
-                goodsuffix[remaining]
-              end
-      index += skip
     end
-  end
 
-  def self.badcharacter_heuristic(str)
-    (0...str.length).reduce({}) do |hash, i|
-      hash[str[i]] = i
-      hash
-    end
-  end
-
-  def self.goodsuffix_heuristic(normal)
-    reversed = normal.reverse
-    prefix_normal = prefix(normal)
-    prefix_reversed = prefix(reversed)
-    result = []
-    (0..normal.size).each do |i|
-      result[i] = normal.size - prefix_normal[normal.size-1]
-    end
-    (0...normal.size).each do |i|
-      j = normal.size - prefix_reversed[i]
-      k = i - prefix_reversed[i]+1
-      result[j] = k if result[j] > k
-    end
-    result
-  end
-
-  def self.prefix(str)
-    k = 0
-    (1...str.length).reduce([0]) do |prefix, q|
-      while (k > 0) && (str[k] != str[q])
-        k = prefix[k-1]
+    def badcharacter_heuristic(str)
+      (0...str.length).reduce({}) do |hash, i|
+        hash[str[i]] = i
+        hash
       end
-      str[k] == str[q] and k += 1
-      prefix[q] = k
-      prefix
+    end
+
+    def goodsuffix_heuristic(normal)
+      reversed = normal.reverse
+      prefix_normal = prefix(normal)
+      prefix_reversed = prefix(reversed)
+      result = []
+      (0..normal.size).each do |i|
+        result[i] = normal.size - prefix_normal[normal.size-1]
+      end
+      (0...normal.size).each do |i|
+        j = normal.size - prefix_reversed[i]
+        k = i - prefix_reversed[i]+1
+        result[j] = k if result[j] > k
+      end
+      result
+    end
+
+    def prefix(str)
+      k = 0
+      (1...str.length).reduce([0]) do |prefix, q|
+        while (k > 0) && (str[k] != str[q])
+          k = prefix[k-1]
+        end
+        str[k] == str[q] and k += 1
+        prefix[q] = k
+        prefix
+      end
     end
   end
 end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,4 +1,4 @@
-require "boyer_moore/version"
+require_relative "./boyer_moore/version"
 
 class RichHash
 

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,27 +1,25 @@
 require_relative "./boyer_moore/version"
 
 module BoyerMoore
-  class << self
-    def search(haystack, needle_string)
-      needle = Needle.new(needle_string)
+  def self.search(haystack, needle_string)
+    needle = Needle.new(needle_string)
 
-      index = 0
-      while index <= haystack.size - needle.size
-        remaining = needle.size
-        while needle[remaining-1] == haystack[index+remaining-1]
-          remaining -= 1
-          remaining == 0 and return index # SUCCESS!
-        end
-
-        char_index = needle.character_index(haystack[index+remaining-1])
-        suffix = needle.good_suffix(remaining)
-        skip =  if char_index < remaining && (m = remaining - char_index - 1) > suffix
-                  m
-                else
-                  suffix
-                end
-        index += skip
+    index = 0
+    while index <= haystack.size - needle.size
+      remaining = needle.size
+      while needle[remaining - 1 ] == haystack[index + remaining - 1]
+        remaining -= 1
+        remaining == 0 and return index # SUCCESS!
       end
+
+      char_index = needle.character_index(haystack[index + remaining - 1])
+      suffix = needle.good_suffix(remaining)
+      skip =  if char_index < remaining && (m = remaining - char_index - 1) > suffix
+                m
+              else
+                suffix
+              end
+      index += skip
     end
   end
 

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -6,13 +6,11 @@ module BoyerMoore
 
     haystack_index = 0
     while haystack_index <= haystack.size - needle.size
-      compare_index = needle.size - 1
-      while needle[compare_index] == haystack[haystack_index + compare_index]
-        compare_index -= 1
-        compare_index < 0 and return haystack_index # SUCCESS!
+      unless mismatch_index = needle.mismatch_index(haystack, haystack_index)
+        break haystack_index # SUCCESS!
       end
 
-      haystack_index += needle.skip_index(haystack[haystack_index + compare_index], compare_index)
+      haystack_index += needle.skip_by(haystack[haystack_index + mismatch_index], mismatch_index)
     end
   end
 
@@ -30,6 +28,15 @@ module BoyerMoore
       @needle[n]
     end
 
+    def mismatch_index(haystack, haystack_index)
+      compare_index = size - 1
+      while @needle[compare_index] == haystack[haystack_index + compare_index]
+        compare_index -= 1
+        compare_index < 0 and return nil
+      end
+      compare_index
+    end
+
     def character_index(char)
       character_indexes[char] || -1
     end
@@ -38,7 +45,7 @@ module BoyerMoore
       good_suffixes[compare_index]
     end
 
-    def skip_index(mismatch_char, compare_index)
+    def skip_by(mismatch_char, compare_index)
       mismatch_char_index = character_index(mismatch_char)
       suffix_index = good_suffix(compare_index + 1)
       if mismatch_char_index <= compare_index && (m = compare_index - mismatch_char_index) > suffix_index

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -49,14 +49,13 @@ module BoyerMoore
 
   def self.compute_prefix(str)
     k = 0
-    result = [0]
-    (1...str.length).each do |q|
+    (1...str.length).reduce([0]) do |prefix, q|
       while (k > 0) && (str[k] != str[q])
-        k = result[k-1]
+        k = prefix[k-1]
       end
       k += 1 if str[k] == str[q]
-      result[q] = k
+      prefix[q] = k
+      prefix
     end
-    result
   end
 end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -28,6 +28,15 @@ module BoyerMoore
       @needle[n]
     end
 
+    def match_or_skip_by(haystack, haystack_index)
+      if mismatch_idx = mismatch_index(haystack, haystack_index)
+        mismatch_char_index = character_index(haystack[haystack_index + mismatch_idx])
+        skip_by(mismatch_char_index, mismatch_idx)
+      end
+    end
+
+  private
+
     def mismatch_index(haystack, haystack_index)
       compare_index = size - 1
       while @needle[compare_index] == haystack[haystack_index + compare_index]
@@ -43,13 +52,6 @@ module BoyerMoore
 
     def good_suffix(compare_index)
       good_suffixes[compare_index]
-    end
-
-    def match_or_skip_by(haystack, haystack_index)
-      if mismatch_idx = mismatch_index(haystack, haystack_index)
-        mismatch_char_index = character_index(haystack[haystack_index + mismatch_idx])
-        skip_by(mismatch_char_index, mismatch_idx)
-      end
     end
 
     def skip_by(mismatch_char_index, compare_index)

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -57,8 +57,8 @@ module BoyerMoore
     def good_suffixes
       @good_suffixes ||=
         begin
-          prefix_normal   = prefix(@needle)
-          prefix_reversed = prefix(@needle.reverse)
+          prefix_normal   = self.class.prefix(@needle)
+          prefix_reversed = self.class.prefix(@needle.reverse)
           result = []
           (0..@needle.size).each do |i|
             result[i] = @needle.size - prefix_normal[@needle.size-1]
@@ -72,7 +72,7 @@ module BoyerMoore
         end
     end
 
-    def prefix(string)
+    def self.prefix(string)
       k = 0
       (1...string.length).reduce([0]) do |prefix, q|
         while k > 0 && string[k] != string[q]

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -44,9 +44,9 @@ module BoyerMoore
     end
 
     def match_or_skip_by(haystack, haystack_index)
-      if mismatch_index = mismatch_index(haystack, haystack_index)
-        mismatch_char = haystack[haystack_index + mismatch_index]
-        skip_by(mismatch_char, mismatch_index)
+      if mismatch_idx = mismatch_index(haystack, haystack_index)
+        mismatch_char = haystack[haystack_index + mismatch_idx]
+        skip_by(mismatch_char, mismatch_idx)
       end
     end
 

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -24,15 +24,12 @@ module BoyerMoore
   end
 
   def self.search(haystack, needle)
-    needle_len = needle.size
-    haystack_len = haystack.size
-    return nil if haystack_len == 0
-    return haystack if needle_len == 0
+    return haystack if needle.size == 0
     badcharacter = prepare_badcharacter_heuristic(needle)
     goodsuffix   = prepare_goodsuffix_heuristic(needle)
     s = 0
-    while s <= haystack_len - needle_len
-      j = needle_len
+    while s <= haystack.size - needle.size
+      j = needle.size
       while (j > 0) && needle_matches?(needle[j-1], haystack[s+j-1])
         j -= 1
       end
@@ -59,16 +56,15 @@ module BoyerMoore
   end
 
   def self.prepare_goodsuffix_heuristic(normal)
-    size = normal.size
     reversed = normal.reverse
     prefix_normal = compute_prefix(normal)
     prefix_reversed = compute_prefix(reversed)
     result = []
-    (0..size).each do |i|
-      result[i] = size - prefix_normal[size-1]
+    (0..normal.size).each do |i|
+      result[i] = normal.size - prefix_normal[normal.size-1]
     end
-    (0...size).each do |i|
-      j = size - prefix_reversed[i]
+    (0...normal.size).each do |i|
+      j = normal.size - prefix_reversed[i]
       k = i - prefix_reversed[i]+1
       result[j] = k if result[j] > k
     end
@@ -84,10 +80,9 @@ module BoyerMoore
   end
 
   def self.compute_prefix(str)
-    size = str.length
     k = 0
     result = [0]
-    (1...size).each do |q|
+    (1...str.length).each do |q|
       while (k > 0) && (str[k] != str[q])
         k = result[k-1]
       end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -6,9 +6,9 @@ module BoyerMoore
 
     haystack_index = 0
     while haystack_index <= haystack.size - needle.size
-      skip_by_index = needle.skip_by_index(haystack, haystack_index) or break haystack_index # SUCCESS!
+      match_or_skip_by = needle.match_or_skip_by(haystack, haystack_index) or break haystack_index # SUCCESS!
 
-      haystack_index += skip_by_index
+      haystack_index += match_or_skip_by
     end
   end
 
@@ -43,7 +43,7 @@ module BoyerMoore
       good_suffixes[compare_index]
     end
 
-    def skip_by_index(haystack, haystack_index)
+    def match_or_skip_by(haystack, haystack_index)
       mismatch_index = mismatch_index(haystack, haystack_index) or
         return nil # SUCCESS!
 

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -6,11 +6,11 @@ module BoyerMoore
 
     haystack_index = 0
     while haystack_index <= haystack.size - needle.size
-      unless mismatch_index = needle.mismatch_index(haystack, haystack_index)
+      mismatch_index = needle.mismatch_index(haystack, haystack_index) or
         break haystack_index # SUCCESS!
-      end
 
-      haystack_index += needle.skip_by(haystack[haystack_index + mismatch_index], mismatch_index)
+      mismatch_char = haystack[haystack_index + mismatch_index]
+      haystack_index += needle.skip_by(mismatch_char, mismatch_index)
     end
   end
 

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -14,10 +14,11 @@ module BoyerMoore
         end
 
         char_index = needle.character_index(haystack[index+remaining-1])
-        skip =  if char_index < remaining && (m = remaining - char_index - 1) > needle.good_suffix[remaining]
+        suffix = needle.good_suffix(remaining)
+        skip =  if char_index < remaining && (m = remaining - char_index - 1) > suffix
                   m
                 else
-                  needle.good_suffix[remaining]
+                  suffix
                 end
         index += skip
       end
@@ -28,10 +29,6 @@ module BoyerMoore
     def initialize(needle)
       needle.size > 0 or raise "Must pass needle with size > 0"
       @needle = needle
-    end
-
-    def to_s
-      @needle
     end
 
     def size
@@ -46,6 +43,11 @@ module BoyerMoore
       character_indexes[char] || -1
     end
 
+    def good_suffix(remaining)
+      good_suffixes[remaining]
+    end
+
+
     def character_indexes
       @char_indexes ||=
         (0...@needle.length).reduce({}) do |hash, i|
@@ -54,8 +56,8 @@ module BoyerMoore
         end
     end
 
-    def good_suffix
-      @good_suffix ||=
+    def good_suffixes
+      @good_suffixes ||=
         begin
           prefix_normal   = prefix(@needle)
           prefix_reversed = prefix(@needle.reverse)

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -6,9 +6,9 @@ module BoyerMoore
 
     haystack_index = 0
     while haystack_index <= haystack.size - needle.size
-      match_or_skip_by = needle.match_or_skip_by(haystack, haystack_index) or break haystack_index # SUCCESS!
+      skip_by = needle.match_or_skip_by(haystack, haystack_index) or break haystack_index # SUCCESS!
 
-      haystack_index += match_or_skip_by
+      haystack_index += skip_by
     end
   end
 
@@ -44,11 +44,10 @@ module BoyerMoore
     end
 
     def match_or_skip_by(haystack, haystack_index)
-      mismatch_index = mismatch_index(haystack, haystack_index) or
-        return nil # SUCCESS!
-
-      mismatch_char = haystack[haystack_index + mismatch_index]
-      skip_by(mismatch_char, mismatch_index)
+      if mismatch_index = mismatch_index(haystack, haystack_index)
+        mismatch_char = haystack[haystack_index + mismatch_index]
+        skip_by(mismatch_char, mismatch_index)
+      end
     end
 
     def skip_by(mismatch_char, compare_index)

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,28 +1,28 @@
 require_relative "./boyer_moore/version"
 
-class RichHash
-  def initialize
-    @regexps = {}
-    @regular = {}
-  end
+module BoyerMoore
+  class RichHash
+    def initialize
+      @regexps = {}
+      @regular = {}
+    end
 
-  def [](k)
-    @regular[k] ||
-      @regexps.find do |regex,v|
-        regex.match(k) and break v
+    def [](k)
+      @regular[k] ||
+        @regexps.find do |regex,v|
+          regex.match(k) and break v
+        end
+    end
+
+    def []=(k,v)
+      if k.kind_of?(Regexp)
+        @regexps[k] = v
+      else
+        @regular[k] = v
       end
-  end
-
-  def []=(k,v)
-    if k.kind_of?(Regexp)
-      @regexps[k] = v
-    else
-      @regular[k] = v
     end
   end
-end
 
-module BoyerMoore
   def self.search(haystack, needle)
     needle_len = needle.size
     haystack_len = haystack.size

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -27,21 +27,21 @@ module BoyerMoore
     needle.size > 0 or raise "Must pass needle with size > 0"
     badcharacter = prepare_badcharacter_heuristic(needle)
     goodsuffix   = prepare_goodsuffix_heuristic(needle)
-    s = 0
-    while s <= haystack.size - needle.size
+    index = 0
+    while index <= haystack.size - needle.size
       j = needle.size
-      while (j > 0) && needle_matches?(needle[j-1], haystack[s+j-1])
+      while (j > 0) && needle_matches?(needle[j-1], haystack[index+j-1])
         j -= 1
       end
       if j > 0
-        k = badcharacter[haystack[s+j-1]] || -1
+        k = badcharacter[haystack[index+j-1]] || -1
         if (k < j) && (m = j-k-1) > goodsuffix[j]
-          s += m
+          index += m
         else
-          s += goodsuffix[j]
+          index += goodsuffix[j]
         end
       else
-        return s
+        return index
       end
     end
     nil

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -30,12 +30,12 @@ module BoyerMoore
     index = 0
     while index <= haystack.size - needle.size
       j = needle.size
-      while (j > 0) && needle_matches?(needle[j-1], haystack[index+j-1])
+      while j > 0 && needle_matches?(needle[j-1], haystack[index+j-1])
         j -= 1
       end
       if j > 0
         k = badcharacter[haystack[index+j-1]] || -1
-        if (k < j) && (m = j-k-1) > goodsuffix[j]
+        if k < j && (m = j-k-1) > goodsuffix[j]
           index += m
         else
           index += goodsuffix[j]

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -25,6 +25,8 @@ module BoyerMoore
       end
     end
 
+    private
+
     def badcharacter_heuristic(str)
       (0...str.length).reduce({}) do |hash, i|
         hash[str[i]] = i

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -33,8 +33,8 @@ module BoyerMoore
 
   def self.goodsuffix_heuristic(normal)
     reversed = normal.reverse
-    prefix_normal = compute_prefix(normal)
-    prefix_reversed = compute_prefix(reversed)
+    prefix_normal = prefix(normal)
+    prefix_reversed = prefix(reversed)
     result = []
     (0..normal.size).each do |i|
       result[i] = normal.size - prefix_normal[normal.size-1]
@@ -47,7 +47,7 @@ module BoyerMoore
     result
   end
 
-  def self.compute_prefix(str)
+  def self.prefix(str)
     k = 0
     (1...str.length).reduce([0]) do |prefix, q|
       while (k > 0) && (str[k] != str[q])

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -4,7 +4,7 @@ module BoyerMoore
   class << self
     def search(haystack, needle)
       needle.size > 0 or raise "Must pass needle with size > 0"
-      badcharacter = badcharacter_heuristic(needle)
+      char_indexes = character_indexes(needle)
       goodsuffix   = goodsuffix_heuristic(needle)
 
       index = 0
@@ -15,8 +15,8 @@ module BoyerMoore
           remaining == 0 and return index # SUCCESS!
         end
 
-        k = badcharacter[haystack[index+remaining-1]] || -1
-        skip =  if k < remaining && (m = remaining-k-1) > goodsuffix[remaining]
+        char_index = char_indexes[haystack[index+remaining-1]] || -1
+        skip =  if char_index < remaining && (m = remaining - char_index - 1) > goodsuffix[remaining]
                   m
                 else
                   goodsuffix[remaining]
@@ -25,37 +25,37 @@ module BoyerMoore
       end
     end
 
-    private
+  private
 
-    def badcharacter_heuristic(str)
-      (0...str.length).reduce({}) do |hash, i|
-        hash[str[i]] = i
+    def character_indexes(needle)
+      (0...needle.length).reduce({}) do |hash, i|
+        hash[needle[i]] = i
         hash
       end
     end
 
-    def goodsuffix_heuristic(normal)
-      prefix_normal   = prefix(normal)
-      prefix_reversed = prefix(normal.reverse)
+    def goodsuffix_heuristic(needle)
+      prefix_normal   = prefix(needle)
+      prefix_reversed = prefix(needle.reverse)
       result = []
-      (0..normal.size).each do |i|
-        result[i] = normal.size - prefix_normal[normal.size-1]
+      (0..needle.size).each do |i|
+        result[i] = needle.size - prefix_normal[needle.size-1]
       end
-      (0...normal.size).each do |i|
-        j = normal.size - prefix_reversed[i]
+      (0...needle.size).each do |i|
+        j = needle.size - prefix_reversed[i]
         k = i - prefix_reversed[i]+1
         result[j] = k if result[j] > k
       end
       result
     end
 
-    def prefix(str)
+    def prefix(needle)
       k = 0
-      (1...str.length).reduce([0]) do |prefix, q|
-        while (k > 0) && (str[k] != str[q])
+      (1...needle.length).reduce([0]) do |prefix, q|
+        while (k > 0) && (needle[k] != needle[q])
           k = prefix[k-1]
         end
-        str[k] == str[q] and k += 1
+        needle[k] == needle[q] and k += 1
         prefix[q] = k
         prefix
       end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -7,14 +7,14 @@ module BoyerMoore
     index = 0
     while index <= haystack.size - needle.size
       remaining = needle.size
-      while needle[remaining - 1 ] == haystack[index + remaining - 1]
+      while needle[remaining - 1] == haystack[index + remaining - 1]
         remaining -= 1
         remaining == 0 and return index # SUCCESS!
       end
 
-      char_index = needle.character_index(haystack[index + remaining - 1])
+      mismatch_char_index = needle.character_index(haystack[index + remaining - 1])
       suffix_index = needle.good_suffix(remaining)
-      skip =  if char_index < remaining && (m = remaining - char_index - 1) > suffix_index
+      skip =  if mismatch_char_index < remaining && (m = remaining - mismatch_char_index - 1) > suffix_index
                 m
               else
                 suffix_index

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -4,15 +4,15 @@ module BoyerMoore
   def self.search(haystack, needle_string)
     needle = Needle.new(needle_string)
 
-    index = 0
-    while index <= haystack.size - needle.size
-      remaining = needle.size
-      while needle[remaining - 1] == haystack[index + remaining - 1]
-        remaining -= 1
-        remaining == 0 and return index # SUCCESS!
+    haystack_index = 0
+    while haystack_index <= haystack.size - needle.size
+      compare_index = needle.size - 1
+      while needle[compare_index] == haystack[haystack_index + compare_index]
+        compare_index -= 1
+        compare_index < 0 and return haystack_index # SUCCESS!
       end
 
-      index += needle.skip_index(haystack[index + remaining - 1], remaining)
+      haystack_index += needle.skip_index(haystack[haystack_index + compare_index], compare_index)
     end
   end
 
@@ -34,14 +34,14 @@ module BoyerMoore
       character_indexes[char] || -1
     end
 
-    def good_suffix(remaining)
-      good_suffixes[remaining]
+    def good_suffix(compare_index)
+      good_suffixes[compare_index]
     end
 
-    def skip_index(mismatch_char, remaining)
+    def skip_index(mismatch_char, compare_index)
       mismatch_char_index = character_index(mismatch_char)
-      suffix_index = good_suffix(remaining)
-      if mismatch_char_index < remaining && (m = remaining - mismatch_char_index - 1) > suffix_index
+      suffix_index = good_suffix(compare_index + 1)
+      if mismatch_char_index <= compare_index && (m = compare_index - mismatch_char_index) > suffix_index
         m
       else
         suffix_index

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -43,8 +43,8 @@ module BoyerMoore
       end
       (0...needle.size).each do |i|
         j = needle.size - prefix_reversed[i]
-        k = i - prefix_reversed[i]+1
-        result[j] = k if result[j] > k
+        k = i - prefix_reversed[i] + 1
+        result[j] > k and result[j] = k
       end
       result
     end
@@ -52,8 +52,8 @@ module BoyerMoore
     def prefix(needle)
       k = 0
       (1...needle.length).reduce([0]) do |prefix, q|
-        while (k > 0) && (needle[k] != needle[q])
-          k = prefix[k-1]
+        while k > 0 && needle[k] != needle[q]
+          k = prefix[k - 1]
         end
         needle[k] == needle[q] and k += 1
         prefix[q] = k

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -12,14 +12,7 @@ module BoyerMoore
         remaining == 0 and return index # SUCCESS!
       end
 
-      mismatch_char_index = needle.character_index(haystack[index + remaining - 1])
-      suffix_index = needle.good_suffix(remaining)
-      skip =  if mismatch_char_index < remaining && (m = remaining - mismatch_char_index - 1) > suffix_index
-                m
-              else
-                suffix_index
-              end
-      index += skip
+      index += needle.skip_index(haystack[index + remaining - 1], remaining)
     end
   end
 
@@ -45,7 +38,17 @@ module BoyerMoore
       good_suffixes[remaining]
     end
 
-  private
+    def skip_index(mismatch_char, remaining)
+      mismatch_char_index = character_index(mismatch_char)
+      suffix_index = good_suffix(remaining)
+      if mismatch_char_index < remaining && (m = remaining - mismatch_char_index - 1) > suffix_index
+        m
+      else
+        suffix_index
+      end
+    end
+
+    private
 
     def character_indexes
       @char_indexes ||=

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -13,11 +13,11 @@ module BoyerMoore
       end
 
       char_index = needle.character_index(haystack[index + remaining - 1])
-      suffix = needle.good_suffix(remaining)
-      skip =  if char_index < remaining && (m = remaining - char_index - 1) > suffix
+      suffix_index = needle.good_suffix(remaining)
+      skip =  if char_index < remaining && (m = remaining - char_index - 1) > suffix_index
                 m
               else
-                suffix
+                suffix_index
               end
       index += skip
     end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -45,13 +45,12 @@ module BoyerMoore
 
     def match_or_skip_by(haystack, haystack_index)
       if mismatch_idx = mismatch_index(haystack, haystack_index)
-        mismatch_char = haystack[haystack_index + mismatch_idx]
-        skip_by(mismatch_char, mismatch_idx)
+        mismatch_char_index = character_index(haystack[haystack_index + mismatch_idx])
+        skip_by(mismatch_char_index, mismatch_idx)
       end
     end
 
-    def skip_by(mismatch_char, compare_index)
-      mismatch_char_index = character_index(mismatch_char)
+    def skip_by(mismatch_char_index, compare_index)
       suffix_index = good_suffix(compare_index + 1)
       if mismatch_char_index <= compare_index && (m = compare_index - mismatch_char_index) > suffix_index
         m

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -23,21 +23,20 @@ class RichHash
 end
 
 module BoyerMoore
-
   def self.search(haystack, needle)
     needle_len = needle.size
     haystack_len = haystack.size
     return nil if haystack_len == 0
     return haystack if needle_len == 0
-    badcharacter = self.prepare_badcharacter_heuristic(needle)
-    goodsuffix   = self.prepare_goodsuffix_heuristic(needle)
+    badcharacter = prepare_badcharacter_heuristic(needle)
+    goodsuffix   = prepare_goodsuffix_heuristic(needle)
     s = 0
     while s <= haystack_len - needle_len
       j = needle_len
-      while (j > 0) && self.needle_matches?(needle[j-1], haystack[s+j-1])
+      while (j > 0) && needle_matches?(needle[j-1], haystack[s+j-1])
         j -= 1
       end
-      if(j > 0)
+      if j > 0
         k = badcharacter[haystack[s+j-1]]
         k = -1 unless k
         if (k < j) && (m = j-k-1) > goodsuffix[j]
@@ -49,7 +48,7 @@ module BoyerMoore
         return s
       end
     end
-    return nil
+    nil
   end
 
   def self.prepare_badcharacter_heuristic(str)
@@ -62,10 +61,10 @@ module BoyerMoore
 
   def self.prepare_goodsuffix_heuristic(normal)
     size = normal.size
-    result = []
-    reversed = normal.dup.reverse
+    reversed = normal.reverse
     prefix_normal = compute_prefix(normal)
     prefix_reversed = compute_prefix(reversed)
+    result = []
     0.upto(size) do |i|
       result[i] = size - prefix_normal[size-1]
     end
@@ -79,7 +78,7 @@ module BoyerMoore
 
   def self.needle_matches?(needle, haystack)
     if needle.kind_of?(Regexp)
-      needle.match(haystack) ? true : false
+      needle.match(haystack)
     else
       needle == haystack
     end
@@ -93,10 +92,9 @@ module BoyerMoore
       while (k > 0) && (str[k] != str[q])
         k = result[k-1]
       end
-      k += 1 if(str[k] == str[q])
+      k += 1 if str[k] == str[q]
       result[q] = k
     end
     result
   end
-
 end

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -24,10 +24,6 @@ module BoyerMoore
       @needle.size
     end
 
-    def [](n)
-      @needle[n]
-    end
-
     def match_or_skip_by(haystack, haystack_index)
       if mismatch_idx = mismatch_index(haystack, haystack_index)
         mismatch_char_index = character_index(haystack[haystack_index + mismatch_idx])

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -45,6 +45,7 @@ module BoyerMoore
       good_suffixes[remaining]
     end
 
+  private
 
     def character_indexes
       @char_indexes ||=

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -24,7 +24,7 @@ module BoyerMoore
   end
 
   def self.search(haystack, needle)
-    return haystack if needle.size == 0
+    needle.size > 0 or raise "Must pass needle with size > 0"
     badcharacter = prepare_badcharacter_heuristic(needle)
     goodsuffix   = prepare_goodsuffix_heuristic(needle)
     s = 0

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -6,9 +6,11 @@ module BoyerMoore
 
     haystack_index = 0
     while haystack_index <= haystack.size - needle.size
-      skip_by = needle.match_or_skip_by(haystack, haystack_index) or break haystack_index # SUCCESS!
-
-      haystack_index += skip_by
+      if skip_by = needle.match_or_skip_by(haystack, haystack_index)
+        haystack_index += skip_by
+      else
+        break haystack_index # Found a match at haystack_index!
+      end
     end
   end
 

--- a/lib/boyer_moore/version.rb
+++ b/lib/boyer_moore/version.rb
@@ -1,3 +1,3 @@
 module BoyerMoore
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -3,18 +3,18 @@ require 'boyer_moore'
 describe BoyerMoore do
   describe BoyerMoore::Needle do
     it "should compute prefixes" do
-      expect(BoyerMoore::Needle::prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
-      expect(BoyerMoore::Needle::prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
+      expect(BoyerMoore::Needle::prefix(%w[A N P A N M A N])).to eq [0, 0, 0, 1, 2, 0, 1, 2]
+      expect(BoyerMoore::Needle::prefix(%w[f o o b a r])).to eq [0, 0, 0, 0, 0, 0]
     end
 
     it "should compute character_indexes" do
-      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).send(:character_indexes)).to eq({"A"=>6, "M"=>5, "N"=>7, "P"=>2})
-      expect(BoyerMoore::Needle.new(%w{f o o b a r}).send(:character_indexes)).to eq ({"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5})
+      expect(BoyerMoore::Needle.new(%w[A N P A N M A N]).send(:character_indexes)).to eq({"A"=>6, "M"=>5, "N"=>7, "P"=>2})
+      expect(BoyerMoore::Needle.new(%w[f o o b a r]).send(:character_indexes)).to eq ({"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5})
     end
 
     it "should implement good_suffixes" do
-      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).send(:good_suffixes)).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
-      expect(BoyerMoore::Needle.new(%w{f o o b a r}).send(:good_suffixes)).to eq [6, 6, 6, 6, 6, 6, 1]
+      expect(BoyerMoore::Needle.new(%w[A N P A N M A N]).send(:good_suffixes)).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
+      expect(BoyerMoore::Needle.new(%w[f o o b a r]).send(:good_suffixes)).to eq [6, 6, 6, 6, 6, 6, 1]
     end
   end
 
@@ -35,17 +35,17 @@ describe BoyerMoore do
   
   it "should match characters" do
     {
-      ['a', 'b', 'c'] => 0,
-      ['b', 'c', 'd'] => nil,
-      ['e', 'f', 'g'] => nil,
-      ['m', 'y', ' ', 'd', 'o', 'g', ' ', 'a', 'b', 'c'] => 7
+      %w[a b c] => 0,
+      %w[b c d] => nil,
+      %w[e f g] => nil,
+      %w[m y _ d o g _ a b c] => 7
     }.each do |haystack, position|
       expect(BoyerMoore.search(haystack, ['a', 'b', 'c'])).to eq position
     end
   end
 
   it "should match in the middle of a string" do
-    expect(BoyerMoore.search("xxxfoobarbazxxx".split(//), "foobar".split(//))).to eq 3
+    expect(BoyerMoore.search("xxxfoobarbazxxx".split(''), "foobar".split(''))).to eq 3
   end
 
   it "should match words" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -8,8 +8,8 @@ describe BoyerMoore do
   end
 
   # it "should compute badcharacter heuristics" do
-  #   BoyerMoore.badcharacter_heuristic(%w{A N P A N M A N}).should == {"A"=>6, "M"=>5, "N"=>7, "P"=>2}
-  #   BoyerMoore.badcharacter_heuristic(%w{f o o b a r}).should == {"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5}
+  #   BoyerMoore.character_indexes(%w{A N P A N M A N}).should == {"A"=>6, "M"=>5, "N"=>7, "P"=>2}
+  #   BoyerMoore.character_indexes(%w{f o o b a r}).should == {"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5}
   # end
 
   it "should implement goodsuffix heuristics" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -1,0 +1,96 @@
+require File.dirname(__FILE__) + '/spec_helper'
+require 'boyer_moore'
+
+describe BoyerMoore do
+  it "should compute prefixes" do
+    expect(BoyerMoore.compute_prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
+    expect(BoyerMoore.compute_prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
+  end
+
+  # it "should compute badcharacter heuristics" do
+  #   BoyerMoore.prepare_badcharacter_heuristic(%w{A N P A N M A N}).should == {"A"=>6, "M"=>5, "N"=>7, "P"=>2}
+  #   BoyerMoore.prepare_badcharacter_heuristic(%w{f o o b a r}).should == {"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5}
+  # end
+
+  it "should prepare goodsuffix heuristics" do
+    expect(BoyerMoore.prepare_goodsuffix_heuristic(%w{A N P A N M A N})).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1] 
+    expect(BoyerMoore.prepare_goodsuffix_heuristic(%w{f o o b a r})).to eq [6, 6, 6, 6, 6, 6, 1]
+  end
+
+  it "should search properly" do
+    expect(BoyerMoore.search("ANPANMAN", "ANP")).to eq 0
+    expect(BoyerMoore.search("ANPANMAN", "ANPXX")).to eq nil 
+    expect(BoyerMoore.search("ANPANMAN", "MAN")).to eq 5
+    expect(BoyerMoore.search("foobar", "bar")).to eq 3
+    expect(BoyerMoore.search("foobar", "zar")).to eq nil 
+  end
+
+  it "should match ruby's #index for basic strings" do
+    needle = 'abcab'
+    ['12abcabc', 'abcgghhhaabcabccccc', '123456789abc123abc', 'aabbcc'].each do |hay|
+      expect(BoyerMoore.search(hay, needle)).to eq hay.index(needle)
+    end
+  end
+  
+  it "should match characters" do
+    needle = "abc".split(//)
+    haystacks = {
+      "abc" => 0, 
+      "bcd" => nil,
+      "efg" => nil, 
+      "my dog abc" => 7
+    }
+    haystacks.each do |hay,pos|
+      hay = hay.split(//)
+      expect(BoyerMoore.search(hay, needle)).to eq pos
+    end
+  end
+
+  it "should match in the middle of a string" do
+    expect(BoyerMoore.search("xxxfoobarbazxxx".split(//), "foobar".split(//))).to eq 3
+  end
+
+  it "should match words" do
+    needle = ["foo", "bar"]
+    haystacks = {
+      ["foo", "bar", "baz"] => 0,
+      ["bam", "bar", "bang"] => nil,
+      ["put", "foo", "bar", "bar"] => 1,
+      ["put", "foo", "bar", "foo", "bar"] => 1
+    }
+    haystacks.each do |hay,pos|
+      expect(BoyerMoore.search(hay, needle)).to eq pos
+    end
+  end
+
+  it "should match regular expressions" do
+    needle = [/^\d+$/]
+    haystacks = {
+      ["999"] => 0,
+      ["foo", "99", "x"] => 1,
+      ["foo99", "10", "10"] => 1
+    } 
+    haystacks.each do |hay,pos|
+      expect(BoyerMoore.search(hay, needle)).to eq pos
+    end
+  end
+
+  describe "richhash" do
+    it "should allow regular hash semantics" do
+      h = RichHash.new
+      h[1] = "foo"
+      expect(h[1]).to eq "foo"
+    end
+
+    it "should allow regexp semantics" do
+      h = RichHash.new
+      h["a"] = "b"
+      h[/\d+/] = "bing"
+      expect(h["a"]).to eq "b"
+      expect(h["b"]).to eq nil
+      expect(h["9"]).to eq "bing"
+      expect(h["99"]).to eq "bing"
+      expect(h["a99"]).to eq "bing"
+    end
+  end
+end

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'spec_helper'
 require 'boyer_moore'
 
 describe BoyerMoore do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -3,8 +3,8 @@ require 'boyer_moore'
 
 describe BoyerMoore do
   it "should compute prefixes" do
-    expect(BoyerMoore.prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
-    expect(BoyerMoore.prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
+    expect(BoyerMoore.send(:prefix, %w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
+    expect(BoyerMoore.send(:prefix, %w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
   end
 
   # it "should compute badcharacter heuristics" do
@@ -13,8 +13,8 @@ describe BoyerMoore do
   # end
 
   it "should implement goodsuffix heuristics" do
-    expect(BoyerMoore.goodsuffix_heuristic(%w{A N P A N M A N})).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
-    expect(BoyerMoore.goodsuffix_heuristic(%w{f o o b a r})).to eq [6, 6, 6, 6, 6, 6, 1]
+    expect(BoyerMoore.send(:goodsuffix_heuristic, %w{A N P A N M A N})).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
+    expect(BoyerMoore.send(:goodsuffix_heuristic, %w{f o o b a r})).to eq [6, 6, 6, 6, 6, 6, 1]
   end
 
   it "should search properly" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -13,9 +13,9 @@ describe BoyerMoore do
       expect(BoyerMoore::Needle.new(%w{f o o b a r}).character_indexes).to eq ({"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5})
     end
 
-    it "should implement good_suffix" do
-      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).good_suffix).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
-      expect(BoyerMoore::Needle.new(%w{f o o b a r}).good_suffix).to eq [6, 6, 6, 6, 6, 6, 1]
+    it "should implement good_suffixes" do
+      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).good_suffixes).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
+      expect(BoyerMoore::Needle.new(%w{f o o b a r}).good_suffixes).to eq [6, 6, 6, 6, 6, 6, 1]
     end
   end
 

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -8,8 +8,8 @@ describe BoyerMoore do
     end
 
     it "should compute character_indexes" do
-      expect(BoyerMoore::Needle.new(%w[A N P A N M A N]).send(:character_indexes)).to eq({"A"=>6, "M"=>5, "N"=>7, "P"=>2})
-      expect(BoyerMoore::Needle.new(%w[f o o b a r]).send(:character_indexes)).to eq ({"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5})
+      expect(BoyerMoore::Needle.new(%w[A N P A N M A N]).send(:character_indexes)).to eq("A"=>6, "M"=>5, "N"=>7, "P"=>2)
+      expect(BoyerMoore::Needle.new(%w[f o o b a r]).send(:character_indexes)).to eq("a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5)
     end
 
     it "should implement good_suffixes" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -57,34 +57,4 @@ describe BoyerMoore do
       expect(BoyerMoore.search(haystack, ["foo", "bar"])).to eq position
     end
   end
-
-  it "should match regular expressions" do
-    needle = [/^\d+$/]
-    {
-      ["999"] => 0,
-      ["foo", "99", "x"] => 1,
-      ["foo99", "10", "10"] => 1
-    }.each do |haystack, position|
-      expect(BoyerMoore.search(haystack, needle)).to eq position
-    end
-  end
-
-  describe BoyerMoore::RichHash do
-    it "should allow regular hash semantics" do
-      h = BoyerMoore::RichHash.new
-      h[1] = "foo"
-      expect(h[1]).to eq "foo"
-    end
-
-    it "should allow regexp semantics" do
-      h = BoyerMoore::RichHash.new
-      h["a"] = "b"
-      h[/\d+/] = "bing"
-      expect(h["a"]).to eq "b"
-      expect(h["b"]).to eq nil
-      expect(h["9"]).to eq "bing"
-      expect(h["99"]).to eq "bing"
-      expect(h["a99"]).to eq "bing"
-    end
-  end
 end

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -2,19 +2,21 @@ require File.dirname(__FILE__) + '/spec_helper'
 require 'boyer_moore'
 
 describe BoyerMoore do
-  it "should compute prefixes" do
-    expect(BoyerMoore.send(:prefix, %w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
-    expect(BoyerMoore.send(:prefix, %w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
-  end
+  describe BoyerMoore::Needle do
+    it "should compute prefixes" do
+      expect(BoyerMoore::Needle.new("abc").prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
+      expect(BoyerMoore::Needle.new("abc").prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
+    end
 
-  # it "should compute badcharacter heuristics" do
-  #   BoyerMoore.character_indexes(%w{A N P A N M A N}).should == {"A"=>6, "M"=>5, "N"=>7, "P"=>2}
-  #   BoyerMoore.character_indexes(%w{f o o b a r}).should == {"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5}
-  # end
+    it "should compute character_indexes" do
+      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).character_indexes).to eq({"A"=>6, "M"=>5, "N"=>7, "P"=>2})
+      expect(BoyerMoore::Needle.new(%w{f o o b a r}).character_indexes).to eq ({"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5})
+    end
 
-  it "should implement goodsuffix heuristics" do
-    expect(BoyerMoore.send(:goodsuffix_heuristic, %w{A N P A N M A N})).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
-    expect(BoyerMoore.send(:goodsuffix_heuristic, %w{f o o b a r})).to eq [6, 6, 6, 6, 6, 6, 1]
+    it "should implement good_suffix" do
+      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).good_suffix).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
+      expect(BoyerMoore::Needle.new(%w{f o o b a r}).good_suffix).to eq [6, 6, 6, 6, 6, 6, 1]
+    end
   end
 
   it "should search properly" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -3,8 +3,8 @@ require 'boyer_moore'
 
 describe BoyerMoore do
   it "should compute prefixes" do
-    expect(BoyerMoore.compute_prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
-    expect(BoyerMoore.compute_prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
+    expect(BoyerMoore.prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
+    expect(BoyerMoore.prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
   end
 
   # it "should compute badcharacter heuristics" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -27,22 +27,19 @@ describe BoyerMoore do
 
   it "should match ruby's #index for basic strings" do
     needle = 'abcab'
-    ['12abcabc', 'abcgghhhaabcabccccc', '123456789abc123abc', 'aabbcc'].each do |hay|
-      expect(BoyerMoore.search(hay, needle)).to eq hay.index(needle)
+    ['12abcabc', 'abcgghhhaabcabccccc', '123456789abc123abc', 'aabbcc'].each do |haystack|
+      expect(BoyerMoore.search(haystack, needle)).to eq haystack.index(needle)
     end
   end
   
   it "should match characters" do
-    needle = "abc".split(//)
-    haystacks = {
-      "abc" => 0, 
-      "bcd" => nil,
-      "efg" => nil, 
-      "my dog abc" => 7
-    }
-    haystacks.each do |hay,pos|
-      hay = hay.split(//)
-      expect(BoyerMoore.search(hay, needle)).to eq pos
+    {
+      ['a', 'b', 'c'] => 0,
+      ['b', 'c', 'd'] => nil,
+      ['e', 'f', 'g'] => nil,
+      ['m', 'y', ' ', 'd', 'o', 'g', ' ', 'a', 'b', 'c'] => 7
+    }.each do |haystack, position|
+      expect(BoyerMoore.search(haystack, ['a', 'b', 'c'])).to eq position
     end
   end
 
@@ -51,27 +48,24 @@ describe BoyerMoore do
   end
 
   it "should match words" do
-    needle = ["foo", "bar"]
-    haystacks = {
+    {
       ["foo", "bar", "baz"] => 0,
       ["bam", "bar", "bang"] => nil,
       ["put", "foo", "bar", "bar"] => 1,
       ["put", "foo", "bar", "foo", "bar"] => 1
-    }
-    haystacks.each do |hay,pos|
-      expect(BoyerMoore.search(hay, needle)).to eq pos
+    }.each do |haystack, position|
+      expect(BoyerMoore.search(haystack, ["foo", "bar"])).to eq position
     end
   end
 
   it "should match regular expressions" do
     needle = [/^\d+$/]
-    haystacks = {
+    {
       ["999"] => 0,
       ["foo", "99", "x"] => 1,
       ["foo99", "10", "10"] => 1
-    } 
-    haystacks.each do |hay,pos|
-      expect(BoyerMoore.search(hay, needle)).to eq pos
+    }.each do |haystack, position|
+      expect(BoyerMoore.search(haystack, needle)).to eq position
     end
   end
 

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -9,13 +9,13 @@ describe BoyerMoore do
     end
 
     it "should compute character_indexes" do
-      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).character_indexes).to eq({"A"=>6, "M"=>5, "N"=>7, "P"=>2})
-      expect(BoyerMoore::Needle.new(%w{f o o b a r}).character_indexes).to eq ({"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5})
+      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).send(:character_indexes)).to eq({"A"=>6, "M"=>5, "N"=>7, "P"=>2})
+      expect(BoyerMoore::Needle.new(%w{f o o b a r}).send(:character_indexes)).to eq ({"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5})
     end
 
     it "should implement good_suffixes" do
-      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).good_suffixes).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
-      expect(BoyerMoore::Needle.new(%w{f o o b a r}).good_suffixes).to eq [6, 6, 6, 6, 6, 6, 1]
+      expect(BoyerMoore::Needle.new(%w{A N P A N M A N}).send(:good_suffixes)).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
+      expect(BoyerMoore::Needle.new(%w{f o o b a r}).send(:good_suffixes)).to eq [6, 6, 6, 6, 6, 6, 1]
     end
   end
 

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -4,8 +4,8 @@ require 'boyer_moore'
 describe BoyerMoore do
   describe BoyerMoore::Needle do
     it "should compute prefixes" do
-      expect(BoyerMoore::Needle.new("abc").prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
-      expect(BoyerMoore::Needle.new("abc").prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
+      expect(BoyerMoore::Needle::prefix(%w{A N P A N M A N})).to eq [0, 0, 0, 1, 2, 0, 1, 2]
+      expect(BoyerMoore::Needle::prefix(%w{f o o b a r})).to eq [0, 0, 0, 0, 0, 0]
     end
 
     it "should compute character_indexes" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -75,15 +75,15 @@ describe BoyerMoore do
     end
   end
 
-  describe "richhash" do
+  describe BoyerMoore::RichHash do
     it "should allow regular hash semantics" do
-      h = RichHash.new
+      h = BoyerMoore::RichHash.new
       h[1] = "foo"
       expect(h[1]).to eq "foo"
     end
 
     it "should allow regexp semantics" do
-      h = RichHash.new
+      h = BoyerMoore::RichHash.new
       h["a"] = "b"
       h[/\d+/] = "bing"
       expect(h["a"]).to eq "b"

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -8,13 +8,13 @@ describe BoyerMoore do
   end
 
   # it "should compute badcharacter heuristics" do
-  #   BoyerMoore.prepare_badcharacter_heuristic(%w{A N P A N M A N}).should == {"A"=>6, "M"=>5, "N"=>7, "P"=>2}
-  #   BoyerMoore.prepare_badcharacter_heuristic(%w{f o o b a r}).should == {"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5}
+  #   BoyerMoore.badcharacter_heuristic(%w{A N P A N M A N}).should == {"A"=>6, "M"=>5, "N"=>7, "P"=>2}
+  #   BoyerMoore.badcharacter_heuristic(%w{f o o b a r}).should == {"a"=>4, "b"=>3, "o"=>2, "f"=>0, "r"=>5}
   # end
 
-  it "should prepare goodsuffix heuristics" do
-    expect(BoyerMoore.prepare_goodsuffix_heuristic(%w{A N P A N M A N})).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1] 
-    expect(BoyerMoore.prepare_goodsuffix_heuristic(%w{f o o b a r})).to eq [6, 6, 6, 6, 6, 6, 1]
+  it "should implement goodsuffix heuristics" do
+    expect(BoyerMoore.goodsuffix_heuristic(%w{A N P A N M A N})).to eq [6, 6, 6, 6, 6, 6, 3, 3, 1]
+    expect(BoyerMoore.goodsuffix_heuristic(%w{f o o b a r})).to eq [6, 6, 6, 6, 6, 6, 1]
   end
 
   it "should search properly" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require_relative 'spec_helper'
 require 'boyer_moore'
 
 describe BoyerMoore do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+$TESTING=true
+$:.push File.join(File.dirname(__FILE__), '..', 'lib')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,0 @@
-$TESTING=true
-$:.push File.join(File.dirname(__FILE__), '..', 'lib')


### PR DESCRIPTION
Hello,

I added back the specs, then refactored this code.  I removed the `Regexp` support since that was cluttering the logic and of dubious value. I moved a lot of the logic into a `Needle` nested class.
